### PR TITLE
Recording: Special characters areen't displayed correctly (Issue 596)

### DIFF
--- a/Recordings.class.php
+++ b/Recordings.class.php
@@ -308,6 +308,8 @@ class Recordings implements BMO {
 				$all = $this->getAll();
 				$languageNames = $this->getLanguages();
 				foreach($all as &$recs) {
+					$recs['displayname'] = html_entity_decode($recs['displayname'], ENT_QUOTES);
+					$recs['description'] = html_entity_decode($recs['description'], ENT_QUOTES);
 					foreach($recs['languages'] as &$lang) {
 						$lang = $languageNames[$lang] ?? $lang;
 					}


### PR DESCRIPTION
When saving a new recording, the name and description are filtered by the function filter_var with the flag "FILTER_SANITIZE_FULL_SPECIAL_CHARS".

Bugfix FreePBX/issue-tracker#596